### PR TITLE
#61: Fix dead-lock during initialization

### DIFF
--- a/src/Frouros.Host/Properties/src.appsettings.json
+++ b/src/Frouros.Host/Properties/src.appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Warning"
     }
   },

--- a/src/Frouros.Proxy/Collections/AsyncEnumerableExtension.cs
+++ b/src/Frouros.Proxy/Collections/AsyncEnumerableExtension.cs
@@ -1,0 +1,17 @@
+﻿namespace Frouros.Proxy.Collections;
+
+public static class AsyncEnumerableExtension
+{
+    public static async Task<IEnumerable<T>> AsTask<T>(this IAsyncEnumerable<T> enumerable)
+    {
+        var list = new Queue<T>();
+        
+        await using var iter = enumerable.GetAsyncEnumerator();
+        while (await iter.MoveNextAsync())
+        {
+            list.Enqueue(iter.Current);
+        }
+
+        return list;
+    }
+}

--- a/src/Frouros.Proxy/Models/Serialization/SourceGenerationContext.cs
+++ b/src/Frouros.Proxy/Models/Serialization/SourceGenerationContext.cs
@@ -23,6 +23,7 @@ namespace Frouros.Proxy.Models.Serialization;
 [JsonSerializable(typeof(Dictionary<uint, Packet>)),
  JsonSerializable(typeof(IPAddress)),
  JsonSerializable(typeof(Log[])),
+ JsonSerializable(typeof(IEnumerable<Log>)),
  JsonSerializable(typeof(ModuleInfo)),
  JsonSerializable(typeof(ModuleActivationInfo)),
  JsonSerializable(typeof(IEnumerable<ModuleInfo>)),

--- a/src/Frouros.Proxy/Services/GrpcServiceProvider.cs
+++ b/src/Frouros.Proxy/Services/GrpcServiceProvider.cs
@@ -29,7 +29,6 @@ public class GrpcServiceProvider : IGrpcServiceProvider
     {
         logger.LogTrace("Creating gRPC channels...");
         _ch = Shared.Net.Grpc.CreateChannel();
-        logger.LogTrace("gRPC channels established");
 
         _services = new Dictionary<Type, ClientBase>
         {
@@ -37,6 +36,7 @@ public class GrpcServiceProvider : IGrpcServiceProvider
             [typeof(PVI.PVIClient)] = new PVI.PVIClient(_ch),
             [typeof(ARP.ARPClient)] = new ARP.ARPClient(_ch)
         }.ToFrozenDictionary();
+        logger.LogTrace("gRPC channels established");
     }
 
     public object? GetService(Type serviceType)

--- a/src/Frouros.Proxy/Workers/Routing/LogRouting.cs
+++ b/src/Frouros.Proxy/Workers/Routing/LogRouting.cs
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 using System.Threading.Channels;
+using Frouros.Proxy.Collections;
 using Frouros.Proxy.Models.Serialization;
 using Frouros.Proxy.Models.Web;
 using Frouros.Shared;
@@ -34,8 +35,8 @@ public class LogRouting(HttpClient http, ILogger<LogRouting> logger) : Backgroun
     {
         while (!token.IsCancellationRequested)
         {
-            if (!_queue.Reader.TryRead(out var logs))
-                continue;
+            var jobs = await _queue.Reader.ReadAllAsync(token).AsTask();
+            var logs = jobs.SelectMany(job => job);
 
             using var response = await http.PostAsJsonAsync(
                 new Uri(Specials.CentralServer, "log"),

--- a/src/Frouros.Proxy/appsettings.json
+++ b/src/Frouros.Proxy/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Warning"
     }
   },


### PR DESCRIPTION
Fix dead-lock during initialization

## Work List

- Enable all log-levels
- Await channels to read
    - Awaiting-task let another thread handle the current synchronization context